### PR TITLE
Deserialization of a lease from StateDictionary problem solved

### DIFF
--- a/src/gateway/IoTEventHubProcessorService/IoTEventHubProcessorService.cs
+++ b/src/gateway/IoTEventHubProcessorService/IoTEventHubProcessorService.cs
@@ -153,8 +153,7 @@ namespace EventHubProcessor
             }
 
             await this.WorkManager.ResumeAsync();
-            // await this.ClearEventHubListeners();
-            await this.RefreshListenersAsync();
+            await this.ClearEventHubListeners();
         }
 
         public async Task Stop()

--- a/src/gateway/IoTEventHubProcessorService/IoTEventHubProcessorService.cs
+++ b/src/gateway/IoTEventHubProcessorService/IoTEventHubProcessorService.cs
@@ -153,7 +153,8 @@ namespace EventHubProcessor
             }
 
             await this.WorkManager.ResumeAsync();
-            await this.ClearEventHubListeners();
+            // await this.ClearEventHubListeners();
+            await this.RefreshListenersAsync();
         }
 
         public async Task Stop()

--- a/src/gateway/IoTProcessorManagement.Common/CommunicationListeners/EventHub/StateManagerLease.cs
+++ b/src/gateway/IoTProcessorManagement.Common/CommunicationListeners/EventHub/StateManagerLease.cs
@@ -70,6 +70,9 @@ namespace IoTProcessorManagement.Common
                 if (cResults.HasValue)
                 {
                     lease = FromJsonString(cResults.Value);
+                    lease.m_EntryName = EntryName;
+                    lease.m_StateDictionary = StateDictionary;
+                    lease.m_StateManager = StateManager;
                 }
                 else
                 {


### PR DESCRIPTION
When deserializing a lease from JsonString, StateManager, StateDictionary and Entryname are not correctly assigned. This cause a systematic error on checkpoint. Added set instructions of correct stateManager, StateDictionary and EntryName whendeserializing.