### PR TITLE
Update IoT-Functions.psm1

### DIFF
--- a/src/gateway/IoTProcessorManagement/PowerShell/IoT-Functions.psm1
+++ b/src/gateway/IoTProcessorManagement/PowerShell/IoT-Functions.psm1
@@ -214,7 +214,7 @@ param
 	else
 	{
 		$IoTProcessorName = Get-IoTProcessorName -IoTProcessor $IoTProcessor
-		$ret =[IoTProcessorManagement.Functions]::GetPrcossor($ManagementEndPoint, $IoTProcessorName)
+		$ret =[IoTProcessorManagement.Functions]::GetProcessor($ManagementEndPoint, $IoTProcessorName)
 		$ret 
 	}
 


### PR DESCRIPTION
Renamed GetPrcossor to GetProcessor based on fixes performed in InternalFunctions.cs and Functions.cs.